### PR TITLE
Implement FastAPI-based DHAL API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+name: Test DHAL API
+
+on: [push, pull_request]
+
+concurrency:
+  # make sure only one run of this workflow for a given PR or a given branch
+  # can happen at one time. previous queued or started runs will be cancelled.
+  # github.workflow is the workflow name
+  # github.ref is the ref that triggered the workflow run
+  # on push, this is refs/heads/<branch name>
+  # on pull request, this is refs/pull/<pull request number>/merge
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+    name: Test (py${{ matrix.python-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch complete history for accurate versioning
+
+      - name: Set up conda environment
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          # Grab requirements from pip-compatible requirements.txt
+          environment-file: requirements.txt
+          condarc: |
+              channels:
+                - conda-forge
+          create-args: >-
+              python=${{ matrix.python-version }}
+              setuptools
+              python-build
+              flake8
+              pytest
+              httpx
+          environment-name: pyenv
+
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          python -m flake8 . --count --ignore=C901 --exit-zero --max-complexity=10 \
+            --max-line-length=127 --statistics
+
+      - name: Install
+        run: |
+            python -m pip install .
+
+      - name: Test with pytest
+        run: python -m pytest tests

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# data-hub-abstraction-layer
-API for querying the NatCap Data Hub from InVEST
+# Data Hub Abstraction Layer API
+
+An API, built with FastAPI, for querying the Natural Capital Alliance Data Hub from InVEST. The goal is to allow InVEST to query the Data Hub for relevant model inputs, directly from the Workbench.
+
+This API takes parameters from InVEST and uses them to construct a query that CKAN / Solr will recognize. It then processes the CKAN query results and returns them in a format better suited for ingestion into InVEST.
+
+## Installation
+
+Required dependencies are listed in `requirements.txt`. If you want to run tests, you will also need to install the dependencies in `requirements-dev.txt`.
+
+## Running the Development API
+
+From within `/fastapi-demo/src/dhal_api/`, run `fastapi dev`. By default, FastAPI uses port `:8000`. The automated docs (which include an interface for testing endpoints) will be available at http://127.0.0.1:8000/docs
+
+### Developing against different versions of the Data Hub
+
+While this API is in early development, `main.py` includes the CKAN URL and relevant Vocabulary IDs for the Prodution and Staging Data Hub sites, as well as for my (Megan's) local CKAN cluster. Simply uncomment the constants relevant to the site you want to test against.
+
+For developing against the staging site: We recently put the Staging Hub behind a password due to increased bot activity. The API has been configured to include an auth header in the session object when making a request to the staging site. You need to have the environment variables `CKAN_STAGING_USERNAME` and `CKAN_STAGING_PASSWORD` set in the environment from which you run `fastapi dev` in order for the auth header to work. Reach out to Megan or James for auth credentials.
+
+Developing against a local CKAN cluster will require updating the `PLACE_VOCAB_ID` and `COLLECTION_VOCAB_ID` to reflect the IDs of those Tag Vocabularies in your CKAN instance. You will also need to uncomment the line in `search_dataset` that sets `session.verify=False`. This is because the development version of CKAN uses a self-signed certificate, resulting in an `SSLCertVerificationError`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Required dependencies are listed in `requirements.txt`. If you want to run tests
 
 ## Running the Development API
 
-From within `/fastapi-demo/src/dhal_api/`, run `fastapi dev`. By default, FastAPI uses port `:8000`. The automated docs (which include an interface for testing endpoints) will be available at http://127.0.0.1:8000/docs
+From within `/src/dhal_api/`, run `fastapi dev`. By default, FastAPI uses port `:8000`. The automated docs (which include an interface for testing endpoints) will be available at http://127.0.0.1:8000/docs
 
 ### Developing against different versions of the Data Hub
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "dhal_api"
+description = "NatCap Data Hub Abstraction Layer API"
+requires-python = ">=3.9"
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
+maintainers = [
+    {name = "Natural Capital Alliance Software Team"}
+]
+
+# the version is provided dynamically by setuptools_scm
+# `dependencies` and `optional-dependencies` are provided by setuptools
+# using the corresponding setup args `install_requires` and `extras_require`
+dynamic = ["version", "dependencies", "optional-dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[build-system]
+requires = ['setuptools>=64', 'wheel', 'setuptools_scm>=8.0']
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+root = ".."
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dhal_api"
 description = "NatCap Data Hub Abstraction Layer API"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 license-files = ["LICENSE.txt"]
 maintainers = [
@@ -16,12 +16,13 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 
+[tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "node-and-date"
+
 [build-system]
 requires = ['setuptools>=64', 'wheel', 'setuptools_scm>=8.0']
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-root = ".."
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+httpx
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ckanapi
 pydantic
 requests
-fastapi
+fastapi[standard]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ckanapi
+pydantic
+requests
+fastapi

--- a/src/dhal_api/main.py
+++ b/src/dhal_api/main.py
@@ -1,0 +1,186 @@
+import json
+import logging
+import os
+import requests
+from typing import Annotated
+
+import ckanapi.errors
+from ckanapi import RemoteCKAN
+from fastapi import FastAPI, Query, Request
+from fastapi.responses import JSONResponse
+
+from dhal_api import utils
+from dhal_api.models import (
+    DataType, LicenseInfo, SearchParams, DatasetSearchResult, SearchResponse
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="Natural Capital Alliance Data Hub Abstraction Layer",
+    description="API for querying the NatCap Data Hub from InVEST.",
+    version="0.1.0"
+)
+
+# Production:
+#CKAN_API_URL = 'https://data.naturalcapitalalliance.stanford.edu'
+#PLACE_VOCAB_ID = '08e541f5-0f71-4931-bfc8-30bf66801146'
+#COLLECTION_VOCAB_ID = '94023b63-78d9-46fb-b688-154d0cd2a8ef'
+
+# Staging:
+CKAN_API_URL = 'https://data-staging.naturalcapitalproject.org'
+PLACE_VOCAB_ID = '10db4d07-a510-4838-ad1b-2adcf4a212f4'
+COLLECTION_VOCAB_ID = '758da202-4bab-46b0-ba53-569ef1a465c8'
+
+# Dev:
+#CKAN_API_URL = 'https://localhost:8443'
+#PLACE_VOCAB_ID = '7320b3ba-1ee9-4fc4-90b3-0240c3aa72df'
+#COLLECTION_VOCAB_ID = '852876fe-49eb-4b88-95d9-44b35facf7ce'
+
+
+class CKANException(Exception):
+    def __init__(self, message: str, status_code: int = 500):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(self.message)
+
+
+@app.exception_handler(CKANException)
+def ckan_exception_handler(request: Request, exc: CKANException) -> JSONResponse:
+    """Handle exceptions thrown by RemoteCKAN."""
+    return JSONResponse(status_code=exc.status_code,
+                        content={
+                            "error_code": exc.status_code,
+                            "error_message": exc.message
+                        })
+
+
+@app.exception_handler(Exception)
+def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Handle any unexpected exceptions."""
+    LOGGER.error(f"Exception: {str(exc)}")
+    return JSONResponse(status_code=500,
+                        content={
+                            "error_code": 500,
+                            "error_message": exc.__str__()
+                        })
+
+
+@app.get("/search_dataset/")
+def search_dataset(filter_query: Annotated[SearchParams, Query()]) -> SearchResponse:
+    """Search for datasets on the Data Hub that match the provided criteria."""
+    session = requests.Session()
+    # For developing against staging, we need to set an auth header:
+    if 'staging' in CKAN_API_URL:
+        session.auth = (os.environ.get('CKAN_STAGING_USERNAME'),
+                        os.environ.get('CKAN_STAGING_PASSWORD'))
+    # For dev: need to set verify=False when working with the dev CKAN container
+#    session.verify = False
+
+    q = utils.tag_search_string_or(filter_query.tags)
+
+    # Skip collections for now:
+    fq_list = ['type:dataset']
+    fq_list.append(
+        f'extras_sources_res_formats:{utils.HUB_DATATYPE_MAP[filter_query.datatype]}')
+    if filter_query.sibling:
+        fq_list.append(f'extras_collection:"{filter_query.sibling.upper()}"')
+
+    extras = {}
+    if filter_query.extent:
+        extras['ext_bbox'] = ','.join((str(coord) for coord in filter_query.extent))
+
+    datasets = []
+    with RemoteCKAN(CKAN_API_URL, session=session) as catalog:
+        offset = 0
+        count = None
+
+        while True:
+            ckan_query_dict = {
+                'q': q,
+                'fq_list': fq_list,
+                'start': offset,
+                'extras': extras,
+                'sort': 'score desc' # Most relevant results first
+            }
+
+            try:
+                result = catalog.action.package_search(**ckan_query_dict)
+            except ckanapi.errors.CKANAPIError as e:
+                LOGGER.exception(
+                    "Exception on RemoteCKAN catalog.action.package_search:"
+                    f" {e}; search parameters: {ckan_query_dict}")
+                raise CKANException(status_code=500, message=f"{e}")
+
+            if 'count' not in result or 'results' not in result:
+                # This shouldn't happen, but check just in case!
+                LOGGER.error(f"CKAN returned unexpected payload: {result}")
+                raise CKANException(status_code=404,
+                                    message="An error occurred in the CKAN search.")
+
+            if not count:
+                count = result.get('count', 0)
+
+            for dataset in result.get('results', []):
+                bbox = None
+                index = 0
+                while index < len(dataset.get('extras', [])):
+                    extra = dataset['extras'][index]
+                    if extra['key'] == 'spatial':
+                        spatial = extra['value']
+                        spatial_dict = json.loads(spatial)
+                        coords = spatial_dict['coordinates']
+                        bbox = [coords[0][0][0], coords[0][1][1],
+                                coords[0][2][0], coords[0][0][1]]
+                        break
+                    index += 1
+
+                dataset_url = None
+                possible_dataset_urls_count = 0
+                index = 0
+                while index < len(dataset.get('resources', [])):
+                    res = dataset['resources'][index]
+                    if utils.resource_type_matches(res['url'], filter_query.datatype):
+                        dataset_url = res['url']
+                        possible_dataset_urls_count += 1
+                        if possible_dataset_urls_count > 1:
+                            # If the resource is ambiguous, skip
+                            dataset_url = None
+                            break
+                    index += 1
+
+                if not dataset_url:
+                    # If no matching resource can be determined, skip
+                    offset += 1
+                    continue
+
+                datasets.append(DatasetSearchResult(
+                    dataset_url=dataset_url,
+                    source_catalog_url=f'{CKAN_API_URL}/dataset/{dataset["name"]}',
+                    name=dataset.get('title'),
+                    description=dataset.get('notes'),
+                    extent=bbox,
+                    tags=[tag['name'] for tag in dataset['tags']
+                          if not tag['vocabulary_id']],
+                    places=[tag['name'] for tag in dataset['tags']
+                            if tag['vocabulary_id'] == PLACE_VOCAB_ID],
+                    collection=[tag['name'] for tag in dataset['tags']
+                            if tag['vocabulary_id'] == COLLECTION_VOCAB_ID],
+                    license=LicenseInfo(
+                        id=dataset.get('license_id'),
+                        title=dataset.get('license_title'),
+                        url=dataset.get('license_url'),
+                    ),
+                    author=dataset.get('author'),
+                    created=dataset.get('metadata_created'),
+                    last_updated=dataset.get('metadata_modified'))
+                )
+                offset += 1
+            if offset >= count:
+                break
+
+    return SearchResponse(
+        count=len(datasets),
+        datasets=datasets
+    )

--- a/src/dhal_api/main.py
+++ b/src/dhal_api/main.py
@@ -82,8 +82,7 @@ def search_dataset(filter_query: Annotated[SearchParams, Query()]) -> SearchResp
 
     # Skip collections for now:
     fq_list = ['type:dataset']
-    fq_list.append(
-        f'extras_sources_res_formats:{utils.HUB_DATATYPE_MAP[filter_query.datatype]}')
+    fq_list.append(utils.resource_type_search_string(filter_query.datatype))
     if filter_query.sibling:
         fq_list.append(f'extras_collection:"{filter_query.sibling.upper()}"')
 

--- a/src/dhal_api/main.py
+++ b/src/dhal_api/main.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 
 from dhal_api import utils
 from dhal_api.models import (
-    DataType, LicenseInfo, SearchParams, DatasetSearchResult, SearchResponse
+    LicenseInfo, SearchParams, DatasetSearchResult, SearchResponse
 )
 
 
@@ -105,7 +105,7 @@ def search_dataset(filter_query: Annotated[SearchParams, Query()]) -> SearchResp
                 'fq_list': fq_list,
                 'start': offset,
                 'extras': extras,
-                'sort': 'score desc' # Most relevant results first
+                'sort': 'score desc'  # Most relevant results first
             }
 
             try:
@@ -165,7 +165,7 @@ def search_dataset(filter_query: Annotated[SearchParams, Query()]) -> SearchResp
                     places=[tag['name'] for tag in dataset['tags']
                             if tag['vocabulary_id'] == PLACE_VOCAB_ID],
                     collection=[tag['name'] for tag in dataset['tags']
-                            if tag['vocabulary_id'] == COLLECTION_VOCAB_ID],
+                                if tag['vocabulary_id'] == COLLECTION_VOCAB_ID],
                     license=LicenseInfo(
                         id=dataset.get('license_id'),
                         title=dataset.get('license_title'),

--- a/src/dhal_api/main.py
+++ b/src/dhal_api/main.py
@@ -92,6 +92,10 @@ def search_dataset(filter_query: Annotated[SearchParams, Query()]) -> SearchResp
 
     datasets = []
     with RemoteCKAN(CKAN_API_URL, session=session) as catalog:
+        # By default, CKAN only returns 10 results per query. To fetch additional
+        # results, we need to make additional queries with `start` set to the offset
+        # in the complete result for where the set of returned datasets should begin.
+        # See: https://docs.ckan.org/en/2.9/api/#ckan.logic.action.get.package_search
         offset = 0
         count = None
 
@@ -114,18 +118,18 @@ def search_dataset(filter_query: Annotated[SearchParams, Query()]) -> SearchResp
 
             if 'count' not in result or 'results' not in result:
                 # This shouldn't happen, but check just in case!
-                LOGGER.error(f"CKAN returned unexpected payload: {result}")
+                error_msg = f"CKAN returned unexpected payload: {result}"
+                LOGGER.error(error_msg)
                 raise CKANException(status_code=404,
-                                    message="An error occurred in the CKAN search.")
+                                    message=error_msg)
 
             if not count:
                 count = result.get('count', 0)
 
             for dataset in result.get('results', []):
+                LOGGER.info(dataset['title'])
                 bbox = None
-                index = 0
-                while index < len(dataset.get('extras', [])):
-                    extra = dataset['extras'][index]
+                for extra in dataset.get('extras', []):
                     if extra['key'] == 'spatial':
                         spatial = extra['value']
                         spatial_dict = json.loads(spatial)
@@ -133,13 +137,10 @@ def search_dataset(filter_query: Annotated[SearchParams, Query()]) -> SearchResp
                         bbox = [coords[0][0][0], coords[0][1][1],
                                 coords[0][2][0], coords[0][0][1]]
                         break
-                    index += 1
 
                 dataset_url = None
                 possible_dataset_urls_count = 0
-                index = 0
-                while index < len(dataset.get('resources', [])):
-                    res = dataset['resources'][index]
+                for res in dataset.get('resources', []):
                     if utils.resource_type_matches(res['url'], filter_query.datatype):
                         dataset_url = res['url']
                         possible_dataset_urls_count += 1
@@ -147,7 +148,6 @@ def search_dataset(filter_query: Annotated[SearchParams, Query()]) -> SearchResp
                             # If the resource is ambiguous, skip
                             dataset_url = None
                             break
-                    index += 1
 
                 if not dataset_url:
                     # If no matching resource can be determined, skip

--- a/src/dhal_api/models.py
+++ b/src/dhal_api/models.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, field_validator
 
 
 class DataType(str, Enum):

--- a/src/dhal_api/models.py
+++ b/src/dhal_api/models.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -24,7 +23,7 @@ class SearchParams(BaseModel):
     """List of keywords from a shared vocabulary between InVEST and the Data Hub."""
     datatype: DataType
     """The file format. One of: raster, vector, or table."""
-    extent: Optional[list[float]] = None
+    extent: list[float] | None = None
     """A 4-element iterable of [minx, miny, maxx, maxy] in EPSG:4326.
     Extent must not include inf or -inf.
     """
@@ -33,28 +32,29 @@ class SearchParams(BaseModel):
 
     @field_validator('extent')
     def validate_extent_length(cls, v):
-        assert len(v) == 4, 'extent must be a list of length 4'
+        if len(v) != 4:
+            raise ValueError('extent must be a list of length 4')
         return v
 
     @field_validator('extent')
     def validate_extent_infinity(cls, v):
         # CKAN spatial search 404s on infinity, after a long wait.
-        assert float('inf') not in v and -float('inf') not in v, (
-                'extent cannot include infinity')
+        if float('inf') in v or -float('inf') in v:
+            raise ValueError('extent cannot include infinity')
         return v
 
 
 class DatasetSearchResult(BaseModel):
     """Class containing details of a Data Hub dataset."""
     dataset_url: str
-    """The URL of the dataset, to be used as an InVEST input."""
+    """The URL of the dataset."""
     source_catalog_url: str
     """The URL to the Package containing the dataset on the Hub."""
     name: str
     """The dataset name."""
     description: str
     """The dataset description."""
-    extent: Optional[list[float]] = None
+    extent: list[float] | None = None
     """A 4-element iterable of [minx, miny, maxx, maxy] in EPSG:4326"""
     tags: list[str]
     """All non-vocabulary tags associated with the dataset."""

--- a/src/dhal_api/models.py
+++ b/src/dhal_api/models.py
@@ -1,0 +1,82 @@
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class DataType(str, Enum):
+    """Class for dataset formats InVEST can request."""
+    raster = 'raster'
+    vector = 'vector'
+    table = 'table'
+
+
+class LicenseInfo(BaseModel):
+    """Class for a dataset's license information."""
+    id: str | None = None
+    title: str | None = None
+    url: str | None = None
+
+
+class SearchParams(BaseModel):
+    """Class for an InVEST input search."""
+    tags: list[str]
+    """List of keywords from a shared vocabulary between InVEST and the Data Hub."""
+    datatype: DataType
+    """The file format. One of: raster, vector, or table."""
+    extent: Optional[list[float]] = None
+    """A 4-element iterable of [minx, miny, maxx, maxy] in EPSG:4326.
+    Extent must not include inf or -inf.
+    """
+    sibling: str | None = None
+    """The relation tag linking two inputs."""
+
+    @field_validator('extent')
+    def validate_extent_length(cls, v):
+        assert len(v) == 4, 'extent must be a list of length 4'
+        return v
+
+    @field_validator('extent')
+    def validate_extent_infinity(cls, v):
+        # CKAN spatial search 404s on infinity, after a long wait.
+        assert float('inf') not in v and -float('inf') not in v, (
+                'extent cannot include infinity')
+        return v
+
+
+class DatasetSearchResult(BaseModel):
+    """Class containing details of a Data Hub dataset."""
+    dataset_url: str
+    """The URL of the dataset, to be used as an InVEST input."""
+    source_catalog_url: str
+    """The URL to the Package containing the dataset on the Hub."""
+    name: str
+    """The dataset name."""
+    description: str
+    """The dataset description."""
+    extent: Optional[list[float]] = None
+    """A 4-element iterable of [minx, miny, maxx, maxy] in EPSG:4326"""
+    tags: list[str]
+    """All non-vocabulary tags associated with the dataset."""
+    places: list[str]
+    """Place vocabulary tags associated with the dataset."""
+    collection: list[str]
+    """The Collections the dataset is a part of. To be used as the
+    `sibling` input in a related search, when relevant.
+    """
+    license: LicenseInfo
+    """Dict containing the license id, title, and url."""
+    author: str
+    """The dataset author."""
+    created: str
+    """The dataset's ``metadata_created`` date."""
+    last_updated: str
+    """The dataset's ``metadata_modified`` date."""
+
+
+class SearchResponse(BaseModel):
+    """Class for search results, including both result count and datasets."""
+    count: int
+    """The number of returned search results."""
+    datasets: list[DatasetSearchResult]
+    """List of DatasetSearchResult objects representing relevant search results."""

--- a/src/dhal_api/utils.py
+++ b/src/dhal_api/utils.py
@@ -4,15 +4,15 @@ from dhal_api.models import DataType
 # Mapping of DataTypes to the values stored in the `sources_res_formats` extra
 # of datasets on the Hub
 HUB_DATATYPE_MAP = {
-    DataType.raster: 'tif',
-    DataType.vector: 'shp',
-    DataType.table: 'csv'
+    DataType.raster: ['tif'],
+    DataType.vector: ['shp', 'gpkg', 'geojson'],
+    DataType.table: ['csv']
 }
 
 # Mapping of DataTypes to relevant file extensions, for extracting the correct
 # Resource from a Data Hub Package
 EXTENSION_MAP = {
-    DataType.vector: ['SHP', 'GEOJSON'],
+    DataType.vector: ['SHP', 'GEOJSON', 'GPKG'],
     DataType.raster: ['TIF', 'TIFF'],
     DataType.table: ['CSV']
 }
@@ -23,6 +23,15 @@ def resource_type_matches(url, datatype):
     extension = url.rsplit('.', 1)[-1].upper()
     if extension in EXTENSION_MAP[datatype]:
         return True
+
+
+def resource_type_search_string(datatype):
+    matching_types = HUB_DATATYPE_MAP[datatype]
+    if len(matching_types) == 1:
+        return f'extras_sources_res_formats:{matching_types[0]}'
+    else:
+        datatype_str = '" OR "'.join(t for t in matching_types)
+        return f'extras_sources_res_formats:("{datatype_str}")'
 
 
 def tag_search_string_and(tags):

--- a/src/dhal_api/utils.py
+++ b/src/dhal_api/utils.py
@@ -1,0 +1,43 @@
+from dhal_api.models import DataType
+
+
+# Mapping of DataTypes to the values stored in the `sources_res_formats` extra
+# of datasets on the Hub
+HUB_DATATYPE_MAP = {
+    DataType.raster: 'tif',
+    DataType.vector: 'shp',
+    DataType.table: 'csv'
+}
+
+# Mapping of DataTypes to relevant file extensions, for extracting the correct
+# Resource from a Data Hub Package
+EXTENSION_MAP = {
+    DataType.vector: ['SHP', 'GEOJSON'],
+    DataType.raster: ['TIF', 'TIFF'],
+    DataType.table: ['CSV']
+}
+
+
+def resource_type_matches(url, datatype):
+    """Check a Resource file extension against the expected datatype."""
+    extension = url.rsplit('.', 1)[-1].upper()
+    if extension in EXTENSION_MAP[datatype]:
+        return True
+
+
+def tag_search_string_and(tags):
+    """Format a search string for tags using AND syntax.
+
+    All tags must be wrapped in double quotes in case they contain whitespace.
+    """
+    tag_str = '" AND "'.join(tag for tag in tags)
+    return f'tags:("{tag_str}")'
+
+
+def tag_search_string_or(tags):
+    """Format a search string for tags using OR syntax.
+
+    All tags must be wrapped in double quotes in case they contain whitespace.
+    """
+    tag_str = '" OR "'.join(tag for tag in tags)
+    return f'tags:("{tag_str}")'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,6 +91,8 @@ class APITests(unittest.TestCase):
 
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
+        # Only one dataset should be returned; the one with ambiguous Resources
+        # should be filtered out
         self.assertEqual(data['count'], 1)
 
         with open(f'{DATA_DIR}/formatted_payload_multiple_resource_match.json') as test_resp:
@@ -105,7 +107,7 @@ class APITests(unittest.TestCase):
         resp = client.get("/search_dataset/", params=params)
 
         self.assertEqual(resp.status_code, 422)
-        assert 'datatype' in resp.json()['detail'][0]['loc']
+        self.assertIn('datatype', resp.json()['detail'][0]['loc'])
 
     def test_search_dataset_bad_query_invalid_extent(self):
         """Test API handles bad query parameters: extent list len < 4."""
@@ -117,7 +119,7 @@ class APITests(unittest.TestCase):
         resp = client.get("/search_dataset/", params=params)
 
         self.assertEqual(resp.status_code, 422)
-        assert 'extent' in resp.json()['detail'][0]['loc']
+        self.assertIn('extent', resp.json()['detail'][0]['loc'])
 
     def test_search_dataset_bad_query_infinity_extent(self):
         """Test API handles bad query parameters: extent includes infinity."""
@@ -129,7 +131,7 @@ class APITests(unittest.TestCase):
         resp = client.get("/search_dataset/", params=params)
 
         self.assertEqual(resp.status_code, 422)
-        assert 'extent' in resp.json()['detail'][0]['loc']
+        self.assertIn('extent', resp.json()['detail'][0]['loc'])
 
     def test_handle_ckan_payload_missing_count_results(self):
         """Handle case where CKAN payload lacks `count` or `results`."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import json
 import os
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from ckanapi.errors import CKANAPIError
 from fastapi.testclient import TestClient

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,162 @@
+import json
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+from ckanapi.errors import CKANAPIError
+from fastapi.testclient import TestClient
+
+from dhal_api.main import app
+
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'test_data')
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+@patch('dhal_api.main.CKAN_API_URL', 'https://data.naturalcapitalalliance.stanford.edu')
+@patch('dhal_api.main.PLACE_VOCAB_ID', '08e541f5-0f71-4931-bfc8-30bf66801146')
+@patch('dhal_api.main.COLLECTION_VOCAB_ID', '94023b63-78d9-46fb-b688-154d0cd2a8ef')
+class APITests(unittest.TestCase):
+
+    def test_search_dataset(self):
+        """Simple test case where CKAN returns one Package."""
+        with open(f'{DATA_DIR}/ckan_response_data_simple.json') as f:
+            success_resp = json.load(f)
+        with patch('dhal_api.main.RemoteCKAN.call_action') as mock_ckan:
+            mock_ckan.return_value = success_resp
+
+            params = {
+                "tags": ["DEM"],
+                "datatype": "raster"
+            }
+            resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['count'], 1)
+
+        with open(f'{DATA_DIR}/formatted_payload_simple.json') as test_resp:
+            expected_data = json.load(test_resp)
+            self.assertEqual(data, expected_data)
+
+    def test_search_dataset_no_results(self):
+        """Test response when no matching datasets found."""
+        with patch('dhal_api.main.RemoteCKAN.call_action') as mock_ckan:
+            mock_ckan.return_value = {'count': 0, 'results': []}
+
+            params = {
+                "tags": ["DEM"],
+                "datatype": "vector"
+            }
+            resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data, {'count': 0, 'datasets': []})
+
+    def test_search_dataset_filter_no_matching_resource(self):
+        """Filter out Package where Resource is ambiguous: no matching filetype."""
+        with open(f'{DATA_DIR}/ckan_response_no_resource_match.json') as f:
+            success_resp = json.load(f)
+        with patch('dhal_api.main.RemoteCKAN.call_action') as mock_ckan:
+            mock_ckan.return_value = success_resp
+
+            params = {
+                "tags": ["COASTLINE"],
+                "datatype": "vector"
+            }
+            resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['count'], 1)
+
+        with open(f'{DATA_DIR}/formatted_payload_no_resource_match.json') as test_resp:
+            expected_data = json.load(test_resp)
+            self.assertEqual(data, expected_data)
+
+    def test_search_dataset_filter_multiple_matching_resources(self):
+        """Filter out Package where Resource is ambiguous: multiple matches."""
+        with open(f'{DATA_DIR}/ckan_response_multiple_resource_match.json') as f:
+            success_resp = json.load(f)
+        with patch('dhal_api.main.RemoteCKAN.call_action') as mock_ckan:
+            mock_ckan.return_value = success_resp
+
+            params = {
+                "tags": ["LULC"],
+                "datatype": "raster"
+            }
+            resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['count'], 1)
+
+        with open(f'{DATA_DIR}/formatted_payload_multiple_resource_match.json') as test_resp:
+            expected_data = json.load(test_resp)
+            self.assertEqual(data, expected_data)
+
+    def test_search_dataset_bad_query_missing_key(self):
+        """Test API handles bad query parameters: missing required key."""
+        params = {
+            "tags": ["DEM"],
+        }
+        resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 422)
+        assert 'datatype' in resp.json()['detail'][0]['loc']
+
+    def test_search_dataset_bad_query_invalid_extent(self):
+        """Test API handles bad query parameters: extent list len < 4."""
+        params = {
+            "tags": ["DEM"],
+            "datatype": "raster",
+            "extent": [-126.56, 25.19, -92.11]
+        }
+        resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 422)
+        assert 'extent' in resp.json()['detail'][0]['loc']
+
+    def test_search_dataset_bad_query_infinity_extent(self):
+        """Test API handles bad query parameters: extent includes infinity."""
+        params = {
+            "tags": ["DEM"],
+            "datatype": "raster",
+            "extent": [float('inf'), -126.56, 25.19, -92.11]
+        }
+        resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 422)
+        assert 'extent' in resp.json()['detail'][0]['loc']
+
+    def test_handle_ckan_payload_missing_count_results(self):
+        """Handle case where CKAN payload lacks `count` or `results`."""
+        with patch('dhal_api.main.RemoteCKAN.call_action') as mock_ckan:
+            mock_ckan.return_value = {'error': 'Something went wrong'}
+
+            params = {
+                "tags": ["DEM"],
+                "datatype": "raster"
+            }
+            resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 404)
+        data = resp.json()
+        self.assertIn("error_message", data.keys())
+
+    def test_handle_ckan_error(self):
+        """Test handling CKANAPIError."""
+        with patch('dhal_api.main.RemoteCKAN.call_action') as mock_ckan:
+            mock_ckan.side_effect = Exception(CKANAPIError)
+
+            params = {
+                "tags": ["DEM"],
+                "datatype": "raster"
+            }
+            resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 500)
+        data = resp.json()
+        self.assertIn("error_message", data.keys())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,6 +40,27 @@ class APITests(unittest.TestCase):
             expected_data = json.load(test_resp)
             self.assertEqual(data, expected_data)
 
+    def test_search_dataset_multiple_valid_filetypes(self):
+        """Test returning Resources of multiple valid file types."""
+        with open(f'{DATA_DIR}/ckan_response_vector_formats.json') as f:
+            success_resp = json.load(f)
+        with patch('dhal_api.main.RemoteCKAN.call_action') as mock_ckan:
+            mock_ckan.return_value = success_resp
+
+            params = {
+                "tags": ["WATERSHEDS"],
+                "datatype": "vector"
+            }
+            resp = client.get("/search_dataset/", params=params)
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['count'], 2)
+
+        with open(f'{DATA_DIR}/formatted_payload_vector_formats.json') as test_resp:
+            expected_data = json.load(test_resp)
+            self.assertEqual(data, expected_data)
+
     def test_search_dataset_no_results(self):
         """Test response when no matching datasets found."""
         with patch('dhal_api.main.RemoteCKAN.call_action') as mock_ckan:

--- a/tests/test_data/ckan_response_data_simple.json
+++ b/tests/test_data/ckan_response_data_simple.json
@@ -1,0 +1,170 @@
+{
+    "count": 1,
+    "facets": {},
+    "results": [
+        {
+            "author": "Natural Capital Project, Stanford University",
+            "author_email": "datahub@naturalcapitalproject.org",
+            "creator_user_id": "7a4d74f2-b39a-4c5b-ab4a-41bbcabfd470",
+            "id": "7206c4bb-f1ed-492f-9029-41d58cdc7df3",
+            "isopen": true,
+            "license_id": "CC-BY-4.0",
+            "license_title": "Creative Commons Attribution 4.0",
+            "license_url": "https://creativecommons.org/licenses/by/4.0/",
+            "metadata_created": "2025-06-13T19:53:53.233509",
+            "metadata_modified": "2025-08-28T19:06:00.531711",
+            "name": "sts-2b13519934614f4b36243eaeab5c712f37043413fb6fc314d588229a47808157",
+            "notes": "NASA DEM HGT version 1 - Global Layer. 30m pixel size. NASADEM 1 arc second (30m) elevation data (collected over the Grand Canyon between 2000-02-11 to 2000-02-21). All tiles were downloaded from NASA Earth Data and stitched into one Cloud Optimized GeoTiff raster. More information on the dataset can be found in the metadata YML file available for download. More information on the source data can found here: https://lpdaac.usgs.gov/products/nasadem_hgtv001/.",
+            "num_resources": 2,
+            "num_tags": 6,
+            "organization": {
+                "id": "db21312f-31cd-4be0-b04a-451b45b6facc",
+                "name": "natcap",
+                "title": "natcap",
+                "type": "organization",
+                "description": "",
+                "image_url": "",
+                "created": "2025-05-15T15:27:25.720453",
+                "is_organization": true,
+                "approval_status": "approved",
+                "state": "active"
+            },
+            "owner_org": "db21312f-31cd-4be0-b04a-451b45b6facc",
+            "private": false,
+            "state": "active",
+            "suggested_citation": "NASA JPL (2020).NASADEM Merged DEM Global 1 arc second V001 [Data set]. NASA EOSDIS Land Processes Distributed Active Archive Center. Accessed 2024-07-02 from https://doi.org/10.5067/MEaSUREs/NASADEM/NASADEM_HGT.001",
+            "title": "NASA HGT DEM - Global Dataset",
+            "type": "dataset",
+            "version": "",
+            "extras": [
+                {
+                    "key": "mappreview",
+                    "value": "{\"map\": {\"minzoom\": [1], \"maxzoom\": [10], \"bounds\": [-179.0001388888889, -56.00013888890444, 179.00013888893648, 61.00013888888889]}, \"layers\": [{\"name\": \"nasa-hgt-v1-1s.tif\", \"type\": \"raster\", \"url\": \"https://storage.googleapis.com/natcap-data-cache/global/nasa-hgt-v1-1s/nasa-hgt-v1-1s.tif\", \"bounds\": [-179.0001388888889, -56.00013888890444, 179.00013888893648, 61.00013888888889], \"minzoom\": 1, \"maxzoom\": 10, \"pixel_min_value\": -332.0, \"pixel_max_value\": 6670.0, \"pixel_percentile_2\": 0.0, \"pixel_percentile_20\": 5.0, \"pixel_percentile_40\": 178.0, \"pixel_percentile_60\": 399.0, \"pixel_percentile_80\": 885.0, \"pixel_percentile_98\": 3683.0}]}"
+                },
+                {
+                    "key": "natcap_last_updated",
+                    "value": "2025-08-28T19:06:00.484114+00:00"
+                },
+                {
+                    "key": "sources",
+                    "value": "[\"https://storage.googleapis.com/natcap-data-cache/global/nasa-hgt-v1-1s/nasa-hgt-v1-1s.tif\"]"
+                },
+                {
+                    "key": "sources_res_formats",
+                    "value": "[\"tif\", \"yml\"]"
+                },
+                {
+                    "key": "spatial",
+                    "value": "{\"type\": \"Polygon\", \"coordinates\": [[[-179.0001388888889, 61.00013888888889], [-179.0001388888889, -56.000138888904445], [179.0001388889365, -56.000138888904445], [179.0001388889365, 61.00013888888889], [-179.0001388888889, 61.00013888888889]]]}"
+                }
+            ],
+            "resources": [
+                {
+                    "cache_last_updated": "2025-08-28T15:05:57.049907",
+                    "cache_url": null,
+                    "created": "2025-08-28T15:05:57.049907",
+                    "datastore_active": false,
+                    "description": "Geometamaker YML",
+                    "format": "YML",
+                    "hash": "sha256:b2f31aeae0d19807db653b0c9f7ed1bdc158526109adbb719799dfa3c733ae08",
+                    "id": "098ec33a-d0e2-442e-a5ab-6a19bef10341",
+                    "last_modified": "2025-08-28T19:05:59.054274",
+                    "metadata_modified": "2025-08-28T19:05:59.197805",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "nasa-hgt-v1-1s.tif.yml",
+                    "package_id": "7206c4bb-f1ed-492f-9029-41d58cdc7df3",
+                    "position": 0,
+                    "resource_type": null,
+                    "size": 2614,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://localhost:8443/dataset/7206c4bb-f1ed-492f-9029-41d58cdc7df3/resource/098ec33a-d0e2-442e-a5ab-6a19bef10341/download/nasa-hgt-v1-1s.tif.yml",
+                    "url_type": "upload"
+                },
+                {
+                    "cache_last_updated": "2025-08-28T15:05:57.050064",
+                    "cache_url": null,
+                    "created": "2025-08-28T15:05:57.050064",
+                    "datastore_active": false,
+                    "description": "NASA DEM HGT version 1 - Global Layer. 30m pixel size. NASADEM 1 arc second (30m) elevation data (collected over the Grand Canyon between 2000-02-11 to 2000-02-21). All tiles were downloaded from NASA Earth Data and stitched into one Cloud Optimized GeoTiff raster. More information on the dataset can be found in the metadata YML file available for download. More information on the source data can found here: https://lpdaac.usgs.gov/products/nasadem_hgtv001/.",
+                    "format": "GeoTIFF",
+                    "hash": "crc32c:m4AdoQ==",
+                    "id": "f5caa9a3-1540-4a57-be7e-655974a37ec5",
+                    "last_modified": null,
+                    "metadata_modified": "2025-08-28T19:05:59.553125",
+                    "mimetype": "image/tiff",
+                    "mimetype_inner": null,
+                    "name": "nasa-hgt-v1-1s.tif",
+                    "package_id": "7206c4bb-f1ed-492f-9029-41d58cdc7df3",
+                    "position": 1,
+                    "resource_type": null,
+                    "size": 183205879271,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://storage.googleapis.com/natcap-data-cache/global/nasa-hgt-v1-1s/nasa-hgt-v1-1s.tif",
+                    "url_type": null
+                }
+            ],
+            "tags": [
+                {
+                    "display_name": "DEM",
+                    "id": "8b8db20a-9877-46a0-81f6-d4d8a7070caf",
+                    "name": "DEM",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "DIGITAL ELEVATION MODEL",
+                    "id": "39b4c954-3807-4e61-a473-67626e3809aa",
+                    "name": "DIGITAL ELEVATION MODEL",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "GLOBAL",
+                    "id": "8c764da5-ed81-4744-be5f-b9ee594f0d97",
+                    "name": "GLOBAL",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "INVEST INPUT",
+                    "id": "8a694d66-9cb0-4869-b2fd-2e113e57f89a",
+                    "name": "INVEST INPUT",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "INVEST-READY",
+                    "id": "66677098-3613-4a62-b197-bfa99b8493cc",
+                    "name": "INVEST-READY",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "NASA",
+                    "id": "61da4878-9e0b-48bb-a951-2b94ec1205d2",
+                    "name": "NASA",
+                    "state": "active",
+                    "vocabulary_id": null
+                }
+            ],
+            "groups": [],
+            "relationships_as_subject": [],
+            "relationships_as_object": [],
+            "tracking_summary": {
+                "total": 0,
+                "recent": 0
+            }
+        }
+    ],
+    "sort": "score desc",
+    "search_facets": {}
+}

--- a/tests/test_data/ckan_response_multiple_resource_match.json
+++ b/tests/test_data/ckan_response_multiple_resource_match.json
@@ -1,0 +1,501 @@
+{
+    "count": 3,
+    "facets": {},
+    "results": [
+        {
+            "author": "Natural Capital Project",
+            "author_email": "datahub@naturalcapitalproject.org",
+            "creator_user_id": "7a4d74f2-b39a-4c5b-ab4a-41bbcabfd470",
+            "id": "5931cb43-714b-4fb0-ae25-4aea24ab04f2",
+            "isopen": true,
+            "license_id": "CC-BY-4.0",
+            "license_title": "Creative Commons Attribution 4.0",
+            "license_url": "https://creativecommons.org/licenses/by/4.0/",
+            "metadata_created": "2026-01-07T17:49:09.299197",
+            "metadata_modified": "2026-01-07T17:49:11.170446",
+            "name": "sts-978d217bca7dcad70896ceae2d1cd484979c7a4a0f139836c16d462336a877ea",
+            "notes": "Global Land Cover Dataset (Adapted from GLC_FCS30D - v1) at 30m resolution for years 1985-2000. This dataset builds off the global, fine-scale land cover dynamic monitoring product (GLC_FCS30D) with a temporal coverage of 1985-2022, to provide global layers as Cloud Optimized geoTIFFs. Data was downloaded from the source and processed by NatCap members at the University of Minnesota. For more information on the processing steps, source data, and land use classifications, please see the 'Lineage' section of the accompanying metadata YAML file.",
+            "num_resources": 2,
+            "num_tags": 4,
+            "organization": {
+                "id": "db21312f-31cd-4be0-b04a-451b45b6facc",
+                "name": "natcap",
+                "title": "natcap",
+                "type": "organization",
+                "description": "",
+                "image_url": "",
+                "created": "2025-05-15T15:27:25.720453",
+                "is_organization": true,
+                "approval_status": "approved",
+                "state": "active"
+            },
+            "owner_org": "db21312f-31cd-4be0-b04a-451b45b6facc",
+            "private": false,
+            "state": "active",
+            "suggested_citation": "",
+            "title": "1985-2000 Global Land Cover Dataset (Adapted from GLC_FCS30D)",
+            "type": "dataset",
+            "version": "",
+            "extras": [
+                {
+                    "key": "natcap_last_updated",
+                    "value": "2026-01-07T17:49:11.133722+00:00"
+                },
+                {
+                    "key": "sources",
+                    "value": "[\"lulc_glc_fcs30d_1985_2000/lulc_glc_fcs30d_1985.tif\", \"lulc_glc_fcs30d_1985_2000/lulc_glc_fcs30d_1985.tif.yml\", \"lulc_glc_fcs30d_1985_2000/lulc_glc_fcs30d_1990.tif\", \"lulc_glc_fcs30d_1985_2000/lulc_glc_fcs30d_1990.tif.yml\", \"lulc_glc_fcs30d_1985_2000/lulc_glc_fcs30d_1995.tif\", \"lulc_glc_fcs30d_1985_2000/lulc_glc_fcs30d_1995.tif.yml\", \"lulc_glc_fcs30d_1985_2000/lulc_glc_fcs30d_2000.tif\", \"lulc_glc_fcs30d_1985_2000/lulc_glc_fcs30d_2000.tif.yml\"]"
+                },
+                {
+                    "key": "sources_res_formats",
+                    "value": "[\"tif\", \"yml\"]"
+                }
+            ],
+            "resources": [
+                {
+                    "cache_last_updated": "2026-01-07T12:48:55.542487",
+                    "cache_url": null,
+                    "created": "2026-01-07T12:48:55.542487",
+                    "datastore_active": false,
+                    "description": "Geometamaker YML",
+                    "format": "YML",
+                    "hash": "crc32c:LN9rug==",
+                    "id": "39e63100-50bb-4eca-82f4-d00a61ef5a7a",
+                    "last_modified": null,
+                    "metadata_modified": "2026-01-07T17:49:09.814734",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "lulc_glc_fcs30d_1985_2000.zip.yml",
+                    "package_id": "5931cb43-714b-4fb0-ae25-4aea24ab04f2",
+                    "position": 0,
+                    "resource_type": null,
+                    "size": 2534,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/collaborator-data/lulc_glc_fcs30d_jjohnson/lulc_glc_fcs30d_1985_2000.zip.yml",
+                    "url_type": null
+                },
+                {
+                    "cache_last_updated": "2026-01-07T12:48:58.828022",
+                    "cache_url": null,
+                    "created": "2026-01-07T12:48:58.828022",
+                    "datastore_active": false,
+                    "description": "Global Land Cover Dataset (Adapted from GLC_FCS30D - v1) at 30m resolution for years 1985-2000. This dataset builds off the global, fine-scale land cover dynamic monitoring product (GLC_FCS30D) with a temporal coverage of 1985-2022, to provide global layers as Cloud Optimized geoTIFFs. Data was downloaded from the source and processed by NatCap members at the University of Minnesota. For more information on the processing steps, source data, and land use classifications, please see the 'Lineage' section of the accompanying metadata YAML file.",
+                    "format": "ZIP",
+                    "hash": "crc32c:cdqJNg==",
+                    "id": "31b0820c-5c51-48fc-9276-6b27387cbe47",
+                    "last_modified": null,
+                    "metadata_modified": "2026-01-07T17:49:10.474525",
+                    "mimetype": "application/zip",
+                    "mimetype_inner": null,
+                    "name": "lulc_glc_fcs30d_1985_2000.zip",
+                    "package_id": "5931cb43-714b-4fb0-ae25-4aea24ab04f2",
+                    "position": 1,
+                    "resource_type": null,
+                    "size": 89816702603,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/collaborator-data/lulc_glc_fcs30d_jjohnson/lulc_glc_fcs30d_1985_2000.zip",
+                    "url_type": null
+                }
+            ],
+            "tags": [
+                {
+                    "display_name": "GLOBAL",
+                    "id": "8c764da5-ed81-4744-be5f-b9ee594f0d97",
+                    "name": "GLOBAL",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "LAND COVER",
+                    "id": "e10119a9-04ed-49cb-9ffb-058b6c5e87c6",
+                    "name": "LAND COVER",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "LAND USE LAND COVER",
+                    "id": "2b6b09e9-9d7a-40c3-a330-fc11b8612b96",
+                    "name": "LAND USE LAND COVER",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "LULC",
+                    "id": "d848340a-5249-4f9e-ae68-34fcbae46072",
+                    "name": "LULC",
+                    "state": "active",
+                    "vocabulary_id": null
+                }
+            ],
+            "groups": [],
+            "relationships_as_subject": [],
+            "relationships_as_object": [],
+            "tracking_summary": {
+                "total": 0,
+                "recent": 0
+            }
+        },
+        {
+            "author": "Natural Capital Project, Stanford University",
+            "author_email": "datahub@naturalcapitalproject.org",
+            "creator_user_id": "7a4d74f2-b39a-4c5b-ab4a-41bbcabfd470",
+            "id": "ff2daf65-3b92-4ade-84ce-f04fb388ed31",
+            "isopen": true,
+            "license_id": "CC-BY-4.0",
+            "license_title": "Creative Commons Attribution 4.0",
+            "license_url": "https://creativecommons.org/licenses/by/4.0/",
+            "metadata_created": "2025-06-27T19:47:57.098766",
+            "metadata_modified": "2025-08-28T19:05:48.398372",
+            "name": "sts-476a98658e58fb224e1c6fdade4cc5ccbc208b441e3f081da455db17eb6f738f",
+            "notes": "This dataset provides a Global ESA 2021 (Version 2) Land Use Land Cover raster file at a resolution of 10m. Included  LULC classes are: Tree cover, Shrubland, Grassland, Cropland, Built-up, Bare/sparse vegetation, Snow and Ice, Permenent water bodies, Herbaceous wetland, Mangroves, and Moss and lichen. Please download the esa2021_classes.csv file alongside the raster for access to the classes legend. This data was accessed from https://worldcover2021.esa.int/download and each tile was downloaded and stitched together into a Global raster by analysts at the Natural Capital Project. The global layer was then converted into a Cloud Optimized GeoTiff with internal overviews. Citation information, and technical documentation, can be found at: https://worldcover2021.esa.int/documentation",
+            "num_resources": 3,
+            "num_tags": 5,
+            "organization": {
+                "id": "db21312f-31cd-4be0-b04a-451b45b6facc",
+                "name": "natcap",
+                "title": "natcap",
+                "type": "organization",
+                "description": "",
+                "image_url": "",
+                "created": "2025-05-15T15:27:25.720453",
+                "is_organization": true,
+                "approval_status": "approved",
+                "state": "active"
+            },
+            "owner_org": "db21312f-31cd-4be0-b04a-451b45b6facc",
+            "private": false,
+            "state": "active",
+            "suggested_citation": "Zanaga, D., Van De Kerchove, R., Daems, D., De Keersmaecker, W., Brockmann, C., Kirches, G., Wevers, J., Cartus, O., Santoro, M., Fritz, S., Lesiv, M., Herold, M., Tsendbazar, N.E., Xu, P., Ramoino, F., Arino, O., 2022. ESA WorldCover 10 m 2021 v200. https://doi.org/10.5281/zenodo.7254221",
+            "title": "ESA WorldCover 2021",
+            "type": "dataset",
+            "version": "",
+            "extras": [
+                {
+                    "key": "natcap_last_updated",
+                    "value": "2025-08-28T19:05:48.355892+00:00"
+                },
+                {
+                    "key": "sources",
+                    "value": "[\"esa2021.tif\", \"esa2021_classes.csv\"]"
+                },
+                {
+                    "key": "sources_res_formats",
+                    "value": "[\"csv\", \"tif\", \"yml\"]"
+                },
+                {
+                    "key": "spatial",
+                    "value": "{\"type\": \"Polygon\", \"coordinates\": [[[-180.0, 84.00000000000001], [-180.0, -59.999999999995005], [179.99999999998747, -59.999999999995005], [179.99999999998747, 84.00000000000001], [-180.0, 84.00000000000001]]]}"
+                }
+            ],
+            "resources": [
+                {
+                    "cache_last_updated": "2025-08-28T15:05:42.246771",
+                    "cache_url": null,
+                    "created": "2025-08-28T15:05:42.246771",
+                    "datastore_active": false,
+                    "description": "Geometamaker YML",
+                    "format": "YML",
+                    "hash": "sha256:5a3502160932b140845ec6d47cad629080e464112f03768d7866438ab0021098",
+                    "id": "0eceedee-f29b-4249-b43b-782546cf5963",
+                    "last_modified": "2025-08-28T19:05:45.694878",
+                    "metadata_modified": "2025-08-28T19:05:45.842841",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "esa2021.tif.yml",
+                    "package_id": "ff2daf65-3b92-4ade-84ce-f04fb388ed31",
+                    "position": 0,
+                    "resource_type": null,
+                    "size": 3516,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://localhost:8443/dataset/ff2daf65-3b92-4ade-84ce-f04fb388ed31/resource/0eceedee-f29b-4249-b43b-782546cf5963/download/esa2021.tif.yml",
+                    "url_type": "upload"
+                },
+                {
+                    "cache_last_updated": "2025-08-28T15:05:42.246911",
+                    "cache_url": null,
+                    "created": "2025-08-28T15:05:42.246911",
+                    "datastore_active": false,
+                    "description": "This dataset provides a Global ESA 2021 (Version 2) Land Use Land Cover raster file at a resolution of 10m. Included  LULC classes are: Tree cover, Shrubland, Grassland, Cropland, Built-up, Bare/sparse vegetation, Snow and Ice, Permenent water bodies, Herbaceous wetland, Mangroves, and Moss and lichen. Please download the esa2021_classes.csv file alongside the raster for access to the classes legend. This data was accessed from https://worldcover2021.esa.int/download and each tile was downloaded and stitched together into a Global raster by analysts at the Natural Capital Project. The global layer was then converted into a Cloud Optimized GeoTiff with internal overviews. Citation information, and technical documentation, can be found at: https://worldcover2021.esa.int/documentation",
+                    "format": "GeoTIFF",
+                    "hash": "crc32c:01nDEg==",
+                    "id": "2a89666b-82ee-499b-80c1-0b5b13c82089",
+                    "last_modified": null,
+                    "metadata_modified": "2025-08-28T19:05:45.987592",
+                    "mimetype": "image/tiff",
+                    "mimetype_inner": null,
+                    "name": "esa2021.tif",
+                    "package_id": "ff2daf65-3b92-4ade-84ce-f04fb388ed31",
+                    "position": 1,
+                    "resource_type": null,
+                    "size": 144511750670,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://storage.googleapis.com/natcap-data-cache/global/esa2021/esa2021.tif",
+                    "url_type": null
+                },
+                {
+                    "cache_last_updated": "2025-08-28T15:05:43.784642",
+                    "cache_url": null,
+                    "created": "2025-08-28T15:05:43.784642",
+                    "datastore_active": false,
+                    "description": "CSV Table",
+                    "format": "Comma Separated Value (.csv)",
+                    "hash": "crc32c:Tbo5WA==",
+                    "id": "93839b9e-0b92-4dda-b75c-6f8f63c44a82",
+                    "last_modified": null,
+                    "metadata_modified": "2025-08-28T19:05:46.144108",
+                    "mimetype": "text/csv",
+                    "mimetype_inner": null,
+                    "name": "esa2021_classes.csv",
+                    "package_id": "ff2daf65-3b92-4ade-84ce-f04fb388ed31",
+                    "position": 2,
+                    "resource_type": null,
+                    "size": 219,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://storage.googleapis.com/natcap-data-cache/global/esa2021/esa2021_classes.csv",
+                    "url_type": null
+                }
+            ],
+            "tags": [
+                {
+                    "display_name": "ESA",
+                    "id": "2ca638e4-4ca2-4241-8db4-442b21dc1f13",
+                    "name": "ESA",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "EUROPEAN SPACE AGENCY",
+                    "id": "10e94874-a372-4016-a60e-b441adc544c9",
+                    "name": "EUROPEAN SPACE AGENCY",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "GLOBAL",
+                    "id": "8c764da5-ed81-4744-be5f-b9ee594f0d97",
+                    "name": "GLOBAL",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "LAND USE LAND COVER",
+                    "id": "2b6b09e9-9d7a-40c3-a330-fc11b8612b96",
+                    "name": "LAND USE LAND COVER",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "LULC",
+                    "id": "d848340a-5249-4f9e-ae68-34fcbae46072",
+                    "name": "LULC",
+                    "state": "active",
+                    "vocabulary_id": null
+                }
+            ],
+            "groups": [],
+            "relationships_as_subject": [],
+            "relationships_as_object": [],
+            "tracking_summary": {
+                "total": 0,
+                "recent": 0
+            }
+        },
+        {
+            "author": "Natural Capital Alliance",
+            "author_email": "datahub@naturalcapitalproject.org",
+            "creator_user_id": "7a4d74f2-b39a-4c5b-ab4a-41bbcabfd470",
+            "id": "fe0566da-033c-4bf7-bb23-f6616f2995d2",
+            "in_collection": [
+                "sts-5a2a758c53fd84b16ddf12a50c54f5f1a62d18964e19fe09a8952231d8fdf71e"
+            ],
+            "isopen": true,
+            "license_id": "CC-BY-4.0",
+            "license_title": "Creative Commons Attribution 4.0",
+            "license_url": "https://creativecommons.org/licenses/by/4.0/",
+            "metadata_created": "2026-02-06T20:37:32.848439",
+            "metadata_modified": "2026-02-11T20:41:42.675839",
+            "name": "sts-6933bfc8ccc2f97614861ccb5bdff660aab7df6554d9387f8f80be5554b3f777",
+            "notes": "2006 Global Land Cover Dataset (Adapted from GLC_FCS30D - v1) at 30m resolution. This dataset builds off the global, fine-scale land cover dynamic monitoring product (GLC_FCS30D) with a temporal coverage of 1985-2022, to provide global layers as Cloud Optimized geoTIFFs. Data was downloaded from the source and processed by NatCap members at the University of Minnesota. For more information on the processing steps, source data, and land use classifications, please see the 'Lineage' section of the accompanying metadata YAML file.",
+            "num_resources": 3,
+            "num_tags": 4,
+            "organization": {
+                "id": "db21312f-31cd-4be0-b04a-451b45b6facc",
+                "name": "natcap",
+                "title": "natcap",
+                "type": "organization",
+                "description": "",
+                "image_url": "",
+                "created": "2025-05-15T15:27:25.720453",
+                "is_organization": true,
+                "approval_status": "approved",
+                "state": "active"
+            },
+            "owner_org": "db21312f-31cd-4be0-b04a-451b45b6facc",
+            "place": [
+                "GLOBAL"
+            ],
+            "private": false,
+            "state": "active",
+            "suggested_citation": "",
+            "title": "2006 Global Land Cover Dataset (Adapted from GLC_FCS30D)",
+            "type": "dataset",
+            "version": "",
+            "extras": [
+                {
+                    "key": "natcap_last_updated",
+                    "value": "2026-02-11T20:41:42.639239+00:00"
+                },
+                {
+                    "key": "sources",
+                    "value": "[\"lulc_glc_fcs30d_2001_2010/lulc_glc_fcs30d_2006.tif\"]"
+                },
+                {
+                    "key": "sources_res_formats",
+                    "value": "[\"tif\", \"yml\"]"
+                },
+                {
+                    "key": "spatial",
+                    "value": "{\"type\": \"Polygon\", \"coordinates\": [[[-180.0, 90.0], [-180.0, -90.0], [180.0, -90.0], [180.0, 90.0], [-180.0, 90.0]]]}"
+                }
+            ],
+            "resources": [
+                {
+                    "cache_last_updated": "2026-02-11T15:41:39.300213",
+                    "cache_url": null,
+                    "created": "2026-02-11T15:41:39.300213",
+                    "datastore_active": false,
+                    "description": "Geometamaker YML",
+                    "format": "YML",
+                    "hash": "crc32c:igcHdA==",
+                    "id": "1c6ab1a0-ec66-407b-8016-4bc99f927bfa",
+                    "last_modified": null,
+                    "metadata_modified": "2026-02-11T20:41:40.919330",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "lulc_glc_fcs30d_2006.tif.yml",
+                    "package_id": "fe0566da-033c-4bf7-bb23-f6616f2995d2",
+                    "position": 0,
+                    "resource_type": null,
+                    "size": 4018,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/collaborator-data/lulc_glc_fcs30d_jjohnson/lulc_glc_fcs30d_2001_2010/lulc_glc_fcs30d_2006.tif.yml",
+                    "url_type": null
+                },
+                {
+                    "cache_last_updated": "2026-02-11T15:41:39.907360",
+                    "cache_url": null,
+                    "created": "2026-02-11T15:41:39.907360",
+                    "datastore_active": false,
+                    "description": "2006 Global Land Cover Dataset (Adapted from GLC_FCS30D - v1) at 30m resolution. This dataset builds off the global, fine-scale land cover dynamic monitoring product (GLC_FCS30D) with a temporal coverage of 1985-2022, to provide global layers as Cloud Optimized geoTIFFs. Data was downloaded from the source and processed by NatCap members at the University of Minnesota. For more information on the processing steps, source data, and land use classifications, please see the 'Lineage' section of the accompanying metadata YAML file.",
+                    "format": "GeoTIFF",
+                    "hash": "crc32c:C2oGoA==",
+                    "id": "accb6f85-3d11-48c0-91fe-93b2c4c3f03c",
+                    "last_modified": null,
+                    "metadata_modified": "2026-02-11T20:41:42.067541",
+                    "mimetype": "image/tiff",
+                    "mimetype_inner": null,
+                    "name": "lulc_glc_fcs30d_2006.tif",
+                    "package_id": "fe0566da-033c-4bf7-bb23-f6616f2995d2",
+                    "position": 1,
+                    "resource_type": null,
+                    "size": 24585439485,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/collaborator-data/lulc_glc_fcs30d_jjohnson/lulc_glc_fcs30d_2001_2010/lulc_glc_fcs30d_2006.tif",
+                    "url_type": null
+                },
+                {
+                    "cache_last_updated": "2026-02-11T15:41:39.907360",
+                    "cache_url": null,
+                    "created": "2026-02-11T15:41:39.907360",
+                    "datastore_active": false,
+                    "description": "2005 Global Land Cover Dataset (Adapted from GLC_FCS30D - v1) at 30m resolution. This dataset builds off the global, fine-scale land cover dynamic monitoring product (GLC_FCS30D) with a temporal coverage of 1985-2022, to provide global layers as Cloud Optimized geoTIFFs. Data was downloaded from the source and processed by NatCap members at the University of Minnesota. For more information on the processing steps, source data, and land use classifications, please see the 'Lineage' section of the accompanying metadata YAML file.",
+                    "format": "GeoTIFF",
+                    "hash": "crc32c:C2oGoA==",
+                    "id": "accb6f85-3d11-48c0-91fe-93b2c4c3f03d",
+                    "last_modified": null,
+                    "metadata_modified": "2026-02-11T20:41:42.067541",
+                    "mimetype": "image/tiff",
+                    "mimetype_inner": null,
+                    "name": "lulc_glc_fcs30d_2005.tif",
+                    "package_id": "fe0566da-033c-4bf7-bb23-f6616f2995d2",
+                    "position": 1,
+                    "resource_type": null,
+                    "size": 24585439485,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/collaborator-data/lulc_glc_fcs30d_jjohnson/lulc_glc_fcs30d_2001_2010/lulc_glc_fcs30d_2005.tif",
+                    "url_type": null
+                }
+            ],
+            "tags": [
+                {
+                    "display_name": "GLOBAL",
+                    "id": "8c764da5-ed81-4744-be5f-b9ee594f0d97",
+                    "name": "GLOBAL",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "LAND COVER",
+                    "id": "e10119a9-04ed-49cb-9ffb-058b6c5e87c6",
+                    "name": "LAND COVER",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "LAND USE LAND COVER",
+                    "id": "2b6b09e9-9d7a-40c3-a330-fc11b8612b96",
+                    "name": "LAND USE LAND COVER",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "LULC",
+                    "id": "d848340a-5249-4f9e-ae68-34fcbae46072",
+                    "name": "LULC",
+                    "state": "active",
+                    "vocabulary_id": null
+                }
+            ],
+            "groups": [],
+            "relationships_as_subject": [],
+            "relationships_as_object": [],
+            "tracking_summary": {
+                "total": 0,
+                "recent": 0
+            }
+        }
+    ],
+    "sort": "score desc",
+    "search_facets": {}
+}

--- a/tests/test_data/ckan_response_no_resource_match.json
+++ b/tests/test_data/ckan_response_no_resource_match.json
@@ -1,0 +1,480 @@
+{
+    "count": 2,
+    "facets": {},
+    "results": [
+        {
+            "author": "Natural Capital Alliance, Stanford University",
+            "author_email": "datahub@naturalcapitalalliance.org",
+            "collection": [],
+            "creator_user_id": "7a4d74f2-b39a-4c5b-ab4a-41bbcabfd470",
+            "id": "f2710799-1200-4cd7-a6ee-21f347f95f3a",
+            "isopen": true,
+            "license_id": "other-pd",
+            "license_title": "Other (Public Domain)",
+            "metadata_created": "2025-08-11T14:01:37.988594",
+            "metadata_modified": "2026-03-31T15:51:45.137092",
+            "name": "sts-c5da8ce35d001559105bf25958c644ef0207b47e6a597f1efb7cb6742225e422",
+            "notes": "This dataset is a product of NOAA's NGS CUSP (Continually Updated Shoreline Product) that provides the most current shorelines of the US and US territories and references mean high water. The data provided by NASA was downloaded and stitched into a single shapefile by members of the NatCap team. This data is continuously updated by the NOAA team and was last downloaded and stitched on 2025-08-07 for the Data Hub. Data will continue to be updated periodically. For more information on the data, including details on the source of the dataset, please see the accompanying metadata (YML) file. For more information from NOAA directly, please visit https://nsde.ngs.noaa.gov/.",
+            "num_resources": 2,
+            "num_tags": 8,
+            "organization": {
+                "id": "db21312f-31cd-4be0-b04a-451b45b6facc",
+                "name": "natcap",
+                "title": "natcap",
+                "type": "organization",
+                "description": "",
+                "image_url": "",
+                "created": "2025-05-15T15:27:25.720453",
+                "is_organization": true,
+                "approval_status": "approved",
+                "state": "active"
+            },
+            "owner_org": "db21312f-31cd-4be0-b04a-451b45b6facc",
+            "place": [
+                "PACIFIC ISLANDS",
+                "PUERTO RICO",
+                "UNITED STATES",
+                "US VIRGIN ISLANDS"
+            ],
+            "private": false,
+            "state": "active",
+            "suggested_citation": "",
+            "title": "NOAA CUSP US Shorelines",
+            "type": "dataset",
+            "version": "",
+            "extras": [
+                {
+                    "key": "center_lat_lon",
+                    "value": "[38.112438411911604, -82.59775114644056]"
+                },
+                {
+                    "key": "mappreview",
+                    "value": "{\"map\": {\"minzoom\": 1, \"maxzoom\": 16, \"bounds\": [-179.1501204, -14.548575, 174.1789486, 71.3877324]}, \"layers\": [{\"name\": \"noaa_us_shorelines.mvt\", \"type\": \"vector\", \"url\": \"https://data.naturalcapitalalliance.stanford.edu/download/global/noaa-us-shorelines/noaa_us_shorelines/noaa_us_shorelines.mvt\", \"bounds\": [-179.1501204, -14.548575, 174.1789486, 71.3877324], \"vector_type\": \"LineString\", \"feature_count\": 968003}]}"
+                },
+                {
+                    "key": "natcap_last_updated",
+                    "value": "2026-03-31T15:51:45.110953+00:00"
+                },
+                {
+                    "key": "sources",
+                    "value": "[\"noaa_us_shorelines/noaa_us_shorelines.cpg\", \"noaa_us_shorelines/noaa_us_shorelines.dbf\", \"noaa_us_shorelines/noaa_us_shorelines.prj\", \"noaa_us_shorelines/noaa_us_shorelines.shp\", \"noaa_us_shorelines/noaa_us_shorelines.shp.yml\", \"noaa_us_shorelines/noaa_us_shorelines.shx\"]"
+                },
+                {
+                    "key": "sources_res_formats",
+                    "value": "[\"shp\", \"yml\"]"
+                }
+            ],
+            "resources": [
+                {
+                    "cache_last_updated": "2026-03-31T11:48:07.601417",
+                    "cache_url": null,
+                    "created": "2026-03-31T11:48:07.601417",
+                    "datastore_active": false,
+                    "description": "Geometamaker YML",
+                    "format": "YML",
+                    "hash": "sha256:6c9087e2ea4c1c4ab1169181ac2b79e689da4dc59e6bb28cc77df1bb3658728b",
+                    "id": "f59731e9-55dd-40b2-a1f0-3024805edaaa",
+                    "last_modified": "2026-03-31T15:51:44.164720",
+                    "metadata_modified": "2026-03-31T15:51:44.300454",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "noaa_us_shorelines.zip.yml",
+                    "package_id": "f2710799-1200-4cd7-a6ee-21f347f95f3a",
+                    "position": 0,
+                    "resource_type": null,
+                    "size": 2573,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://localhost:8443/dataset/f2710799-1200-4cd7-a6ee-21f347f95f3a/resource/f59731e9-55dd-40b2-a1f0-3024805edaaa/download/noaa_us_shorelines.zip.yml",
+                    "url_type": "upload"
+                },
+                {
+                    "cache_last_updated": "2026-03-31T11:48:07.601542",
+                    "cache_url": null,
+                    "created": "2026-03-31T11:48:07.601542",
+                    "datastore_active": false,
+                    "description": "This dataset is a product of NOAA's NGS CUSP (Continually Updated Shoreline Product) that provides the most current shorelines of the US and US territories and references mean high water. The data provided by NASA was downloaded and stitched into a single shapefile by members of the NatCap team. This data is continuously updated by the NOAA team and was last downloaded and stitched on 2025-08-07 for the Data Hub. Data will continue to be updated periodically. For more information on the data, including details on the source of the dataset, please see the accompanying metadata (YML) file. For more information from NOAA directly, please visit https://nsde.ngs.noaa.gov/.",
+                    "format": "ZIP",
+                    "hash": "crc32c:yPuLhA==",
+                    "id": "e81edbe4-a104-4a19-b8f5-d07a06d2c52c",
+                    "last_modified": null,
+                    "metadata_modified": "2026-03-31T15:51:44.730744",
+                    "mimetype": "application/zip",
+                    "mimetype_inner": null,
+                    "name": "noaa_us_shorelines.zip",
+                    "package_id": "f2710799-1200-4cd7-a6ee-21f347f95f3a",
+                    "position": 1,
+                    "resource_type": null,
+                    "size": 2503626407,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/global/noaa-us-shorelines/noaa_us_shorelines.zip",
+                    "url_type": null
+                }
+            ],
+            "tags": [
+                {
+                    "display_name": "COASTAL",
+                    "id": "7388491e-51b1-4feb-bcff-70d70bdc3a28",
+                    "name": "COASTAL",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "COASTLINE",
+                    "id": "ee468205-7c0d-4b2a-b2fe-43500a1ba812",
+                    "name": "COASTLINE",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "NOAA",
+                    "id": "39092611-518c-4dc0-9e9a-cfe3f1088905",
+                    "name": "NOAA",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "PACIFIC ISLANDS",
+                    "id": "7dedab29-44a1-4616-99e2-b6d0b64c2506",
+                    "name": "PACIFIC ISLANDS",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "PUERTO RICO",
+                    "id": "634840da-7253-4f75-b8f5-ce546656705f",
+                    "name": "PUERTO RICO",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "SHORELINES",
+                    "id": "d4e35a6d-fdbc-417a-985c-33b70370578c",
+                    "name": "SHORELINES",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "UNITED STATES",
+                    "id": "f02185bb-d011-45eb-a32d-6bfa985be56f",
+                    "name": "UNITED STATES",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "US VIRGIN ISLANDS",
+                    "id": "1e1a856e-ba8a-4ed6-a163-bda61803f99e",
+                    "name": "US VIRGIN ISLANDS",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                }
+            ],
+            "groups": [],
+            "relationships_as_subject": [],
+            "relationships_as_object": [],
+            "tracking_summary": {
+                "total": 0,
+                "recent": 0
+            }
+        },
+        {
+            "author": "Natural Capital Alliance, Stanford University",
+            "author_email": "datahub@naturalcapitalalliance.org",
+            "collection": [],
+            "creator_user_id": "7a4d74f2-b39a-4c5b-ab4a-41bbcabfd470",
+            "id": "437b089c-b10c-423f-8dd5-a07400d9104d",
+            "isopen": true,
+            "license_id": "other-pd",
+            "license_title": "Other (Public Domain)",
+            "metadata_created": "2026-02-24T19:00:04.857844",
+            "metadata_modified": "2026-03-31T16:05:07.761792",
+            "name": "sts-bf98ba4d4020c364153efb4a324d4e39d2d9e3cc9978d2afdc729fac664069cf",
+            "notes": "This dataset is a product of NOAA's NGS CUSP (Continually Updated Shoreline Product) that provides the most current shorelines of the US and US territories and references mean high water. The data provided by NASA was downloaded and stitched into a single shapefile by members of the NatCap team. This data is continuously updated by the NOAA team and was last downloaded and stitched on 2025-08-01 for the Data Hub. Data will continue to be updated periodically. For more information on the data, including details on the source of the dataset, please see the accompanying metadata (YML) file. For more information from NOAA directly, please visit https://nsde.ngs.noaa.gov/.",
+            "num_resources": 6,
+            "num_tags": 8,
+            "organization": {
+                "id": "db21312f-31cd-4be0-b04a-451b45b6facc",
+                "name": "natcap",
+                "title": "natcap",
+                "type": "organization",
+                "description": "",
+                "image_url": "",
+                "created": "2025-05-15T15:27:25.720453",
+                "is_organization": true,
+                "approval_status": "approved",
+                "state": "active"
+            },
+            "owner_org": "db21312f-31cd-4be0-b04a-451b45b6facc",
+            "place": [
+                "PACIFIC ISLANDS",
+                "PUERTO RICO",
+                "UNITED STATES",
+                "US VIRGIN ISLANDS"
+            ],
+            "private": false,
+            "state": "active",
+            "suggested_citation": "",
+            "title": "NOAA CUSP US Shorelines",
+            "type": "dataset",
+            "version": "",
+            "extras": [
+                {
+                    "key": "center_lat_lon",
+                    "value": "[38.112438411911604, -82.59775114644056]"
+                },
+                {
+                    "key": "mappreview",
+                    "value": "{\"map\": {\"minzoom\": 1, \"maxzoom\": 16, \"bounds\": [-179.1501204, -14.548575, 174.1789486, 71.3877324]}, \"layers\": [{\"name\": \"noaa_us_shorelines.mvt\", \"type\": \"vector\", \"url\": \"https://data.naturalcapitalalliance.stanford.edu/download/global/noaa-us-shorelines/noaa_us_shorelines/noaa_us_shorelines.mvt\", \"bounds\": [-179.1501204, -14.548575, 174.1789486, 71.3877324], \"vector_type\": \"LineString\", \"feature_count\": 968003}]}"
+                },
+                {
+                    "key": "natcap_last_updated",
+                    "value": "2026-03-31T16:05:07.732617+00:00"
+                },
+                {
+                    "key": "sources",
+                    "value": "[\"noaa_us_shorelines.shp\", \"noaa_us_shorelines.shx\", \"noaa_us_shorelines.dbf\", \"noaa_us_shorelines.cpg\", \"noaa_us_shorelines.prj\"]"
+                },
+                {
+                    "key": "sources_res_formats",
+                    "value": "[\"shp\", \"yml\"]"
+                },
+                {
+                    "key": "spatial",
+                    "value": "{\"type\": \"Polygon\", \"coordinates\": [[[-179.1501203785526, 71.38773242211363], [-179.1501203785526, -14.548575000435905], [174.17894858272027, -14.548575000435905], [174.17894858272027, 71.38773242211363], [-179.1501203785526, 71.38773242211363]]]}"
+                }
+            ],
+            "resources": [
+                {
+                    "cache_last_updated": "2026-03-31T11:57:42.496511",
+                    "cache_url": null,
+                    "created": "2026-03-31T11:57:42.496511",
+                    "datastore_active": false,
+                    "description": "Geometamaker YML",
+                    "format": "YML",
+                    "hash": "sha256:681c7c34ba051d63fff8c922ac23b0eb8253910e88d1556d51c2d84dd21d18e6",
+                    "id": "eeb9a7f3-a53f-4922-bbed-6c76b02d36e5",
+                    "last_modified": "2026-03-31T16:05:05.440586",
+                    "metadata_modified": "2026-03-31T16:05:05.604837",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "noaa_us_shorelines.shp.yml",
+                    "package_id": "437b089c-b10c-423f-8dd5-a07400d9104d",
+                    "position": 0,
+                    "resource_type": null,
+                    "size": 4484,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://localhost:8443/dataset/437b089c-b10c-423f-8dd5-a07400d9104d/resource/eeb9a7f3-a53f-4922-bbed-6c76b02d36e5/download/noaa_us_shorelines.shp.yml",
+                    "url_type": "upload"
+                },
+                {
+                    "cache_last_updated": "2026-03-31T11:57:42.496661",
+                    "cache_url": null,
+                    "created": "2026-03-31T11:57:42.496661",
+                    "datastore_active": false,
+                    "description": "This dataset is a product of NOAA's NGS CUSP (Continually Updated Shoreline Product) that provides the most current shorelines of the US and US territories and references mean high water. The data provided by NASA was downloaded and stitched into a single shapefile by members of the NatCap team. This data is continuously updated by the NOAA team and was last downloaded and stitched on 2025-08-01 for the Data Hub. Data will continue to be updated periodically. For more information on the data, including details on the source of the dataset, please see the accompanying metadata (YML) file. For more information from NOAA directly, please visit https://nsde.ngs.noaa.gov/.",
+                    "format": "SHP",
+                    "hash": "crc32c:lLjJ+A==",
+                    "id": "e2f42624-7c92-4b39-ba24-cddd3e9564ad",
+                    "last_modified": null,
+                    "metadata_modified": "2026-03-31T16:05:05.774718",
+                    "mimetype": "application/octet-stream",
+                    "mimetype_inner": null,
+                    "name": "noaa_us_shorelines.shp",
+                    "package_id": "437b089c-b10c-423f-8dd5-a07400d9104d",
+                    "position": 1,
+                    "resource_type": null,
+                    "size": 1222621820,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/global/noaa-us-shorelines/noaa_us_shorelines/noaa_us_shorelines.shp",
+                    "url_type": null
+                },
+                {
+                    "cache_last_updated": "2026-03-31T11:57:45.649508",
+                    "cache_url": null,
+                    "created": "2026-03-31T11:57:45.649508",
+                    "datastore_active": false,
+                    "description": "Resource",
+                    "format": "SHP",
+                    "hash": "crc32c:843+zA==",
+                    "id": "07836721-8a01-4acc-a4bd-eecac139067e",
+                    "last_modified": null,
+                    "metadata_modified": "2026-03-31T16:05:05.955094",
+                    "mimetype": "application/octet-stream",
+                    "mimetype_inner": null,
+                    "name": "noaa_us_shorelines.shx",
+                    "package_id": "437b089c-b10c-423f-8dd5-a07400d9104d",
+                    "position": 2,
+                    "resource_type": null,
+                    "size": 7744124,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/global/noaa-us-shorelines/noaa_us_shorelines/noaa_us_shorelines.shx",
+                    "url_type": null
+                },
+                {
+                    "cache_last_updated": "2026-03-31T11:57:46.626088",
+                    "cache_url": null,
+                    "created": "2026-03-31T11:57:46.626088",
+                    "datastore_active": false,
+                    "description": "Resource",
+                    "format": "SHP",
+                    "hash": "crc32c:C+bFkQ==",
+                    "id": "3a836821-7f2d-4881-8176-b60584e5547f",
+                    "last_modified": null,
+                    "metadata_modified": "2026-03-31T16:05:06.130172",
+                    "mimetype": "application/dbase",
+                    "mimetype_inner": null,
+                    "name": "noaa_us_shorelines.dbf",
+                    "package_id": "437b089c-b10c-423f-8dd5-a07400d9104d",
+                    "position": 3,
+                    "resource_type": null,
+                    "size": 976715509,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/global/noaa-us-shorelines/noaa_us_shorelines/noaa_us_shorelines.dbf",
+                    "url_type": null
+                },
+                {
+                    "cache_last_updated": "2026-03-31T11:57:47.598971",
+                    "cache_url": null,
+                    "created": "2026-03-31T11:57:47.598971",
+                    "datastore_active": false,
+                    "description": "Resource",
+                    "format": "CPG",
+                    "hash": "crc32c:D+zN3A==",
+                    "id": "77ad7b05-55b5-4637-a6b8-52e679238c17",
+                    "last_modified": null,
+                    "metadata_modified": "2026-03-31T16:05:06.490801",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "noaa_us_shorelines.cpg",
+                    "package_id": "437b089c-b10c-423f-8dd5-a07400d9104d",
+                    "position": 4,
+                    "resource_type": null,
+                    "size": 5,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/global/noaa-us-shorelines/noaa_us_shorelines/noaa_us_shorelines.cpg",
+                    "url_type": null
+                },
+                {
+                    "cache_last_updated": "2026-03-31T11:57:49.037524",
+                    "cache_url": null,
+                    "created": "2026-03-31T11:57:49.037524",
+                    "datastore_active": false,
+                    "description": "Resource",
+                    "format": "PRJ",
+                    "hash": "crc32c:PKFdqg==",
+                    "id": "48e71c12-f84e-4a60-ad0a-1179c608c29d",
+                    "last_modified": null,
+                    "metadata_modified": "2026-03-31T16:05:06.695662",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "noaa_us_shorelines.prj",
+                    "package_id": "437b089c-b10c-423f-8dd5-a07400d9104d",
+                    "position": 5,
+                    "resource_type": null,
+                    "size": 145,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/download/global/noaa-us-shorelines/noaa_us_shorelines/noaa_us_shorelines.prj",
+                    "url_type": null
+                }
+            ],
+            "tags": [
+                {
+                    "display_name": "COASTAL",
+                    "id": "7388491e-51b1-4feb-bcff-70d70bdc3a28",
+                    "name": "COASTAL",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "COASTLINE",
+                    "id": "ee468205-7c0d-4b2a-b2fe-43500a1ba812",
+                    "name": "COASTLINE",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "NOAA",
+                    "id": "39092611-518c-4dc0-9e9a-cfe3f1088905",
+                    "name": "NOAA",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "PACIFIC ISLANDS",
+                    "id": "7dedab29-44a1-4616-99e2-b6d0b64c2506",
+                    "name": "PACIFIC ISLANDS",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "PUERTO RICO",
+                    "id": "634840da-7253-4f75-b8f5-ce546656705f",
+                    "name": "PUERTO RICO",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "SHORELINES",
+                    "id": "d4e35a6d-fdbc-417a-985c-33b70370578c",
+                    "name": "SHORELINES",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "UNITED STATES",
+                    "id": "f02185bb-d011-45eb-a32d-6bfa985be56f",
+                    "name": "UNITED STATES",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                },
+                {
+                    "display_name": "US VIRGIN ISLANDS",
+                    "id": "1e1a856e-ba8a-4ed6-a163-bda61803f99e",
+                    "name": "US VIRGIN ISLANDS",
+                    "state": "active",
+                    "vocabulary_id": "08e541f5-0f71-4931-bfc8-30bf66801146"
+                }
+            ],
+            "groups": [],
+            "relationships_as_subject": [],
+            "relationships_as_object": [],
+            "tracking_summary": {
+                "total": 0,
+                "recent": 0
+            }
+        }
+    ],
+    "sort": "score desc",
+    "search_facets": {}
+}

--- a/tests/test_data/ckan_response_vector_formats.json
+++ b/tests/test_data/ckan_response_vector_formats.json
@@ -1,0 +1,286 @@
+{
+    "count": 2,
+    "facets": {},
+    "results": [
+        {
+            "author": "The Natural Capital Project, Stanford University",
+            "author_email": "datahub@naturalcapitalproject.org",
+            "collection": [],
+            "creator_user_id": "7a4d74f2-b39a-4c5b-ab4a-41bbcabfd470",
+            "id": "41c970f4-20ba-4263-8573-a66bba42202e",
+            "isopen": true,
+            "license_id": "CC-BY-4.0",
+            "license_title": "Creative Commons Attribution 4.0",
+            "license_url": "https://creativecommons.org/licenses/by/4.0/",
+            "metadata_created": "2026-04-24T20:12:43.322088",
+            "metadata_modified": "2026-04-24T20:17:02.885906",
+            "name": "sts-dafff9535f9b2b329ec61e85a481a16776304708af291ddc5792f8d695278264",
+            "notes": "A vector defining the areas that are upstream from the snapped outlet points, where upstream area is defined by the D8 flow algorithm implementation in PyGeoprocessing.",
+            "num_resources": 2,
+            "num_tags": 3,
+            "organization": {
+                "id": "db21312f-31cd-4be0-b04a-451b45b6facc",
+                "name": "natcap",
+                "title": "natcap",
+                "type": "organization",
+                "description": "",
+                "image_url": "",
+                "created": "2025-05-15T15:27:25.720453",
+                "is_organization": true,
+                "approval_status": "approved",
+                "state": "active"
+            },
+            "owner_org": "db21312f-31cd-4be0-b04a-451b45b6facc",
+            "place": [],
+            "private": false,
+            "state": "active",
+            "suggested_citation": "",
+            "title": "Subwatersheds from DelineateIt for Testing",
+            "type": "dataset",
+            "version": "",
+            "extras": [
+                {
+                    "key": "center_lat_lon",
+                    "value": "[-0.5658684233756568, 36.83720533394234]"
+                },
+                {
+                    "key": "sources",
+                    "value": "[\"/watersheds_gura.gpkg\"]"
+                },
+                {
+                    "key": "sources_res_formats",
+                    "value": "[\"gpkg\", \"yml\"]"
+                },
+                {
+                    "key": "spatial",
+                    "value": "{\"type\": \"Polygon\", \"coordinates\": [[[36.744343840599385, -0.5359785856603112], [36.744343840599385, -0.60712559476077], [36.97163097658486, -0.60712559476077], [36.97163097658486, -0.5359785856603112], [36.744343840599385, -0.5359785856603112]]]}"
+                }
+            ],
+            "resources": [
+                {
+                    "cache_last_updated": "2026-04-24T16:17:02.384338",
+                    "cache_url": null,
+                    "created": "2026-04-24T16:17:02.384338",
+                    "datastore_active": false,
+                    "description": "Geometamaker YML",
+                    "format": "YML",
+                    "hash": "sha256:ca44ea57f7e1a6ffcefcd4db4b6ea6e7b514ca31ef4a9ed6ed1878faef84f723",
+                    "id": "0dc164cd-1833-4cd1-ae32-e108266f6ed3",
+                    "last_modified": "2026-04-24T20:17:02.619656",
+                    "metadata_modified": "2026-04-24T20:17:02.887919",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "watersheds_gura.gpkg.yml",
+                    "package_id": "41c970f4-20ba-4263-8573-a66bba42202e",
+                    "position": 0,
+                    "resource_type": null,
+                    "size": 2113,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/dataset/41c970f4-20ba-4263-8573-a66bba42202e/resource/0dc164cd-1833-4cd1-ae32-e108266f6ed3/download/watersheds_gura.gpkg.yml",
+                    "url_type": "upload"
+                },
+                {
+                    "cache_last_updated": "2026-04-24T16:17:02.384886",
+                    "cache_url": null,
+                    "created": "2026-04-24T16:17:02.384885",
+                    "datastore_active": false,
+                    "description": "A vector defining the areas that are upstream from the snapped outlet points, where upstream area is defined by the D8 flow algorithm implementation in PyGeoprocessing.",
+                    "format": ".gpkg",
+                    "hash": "",
+                    "id": "12bd28ca-9e59-40d6-8e5b-87e30b2b79db",
+                    "last_modified": null,
+                    "metadata_modified": "2026-04-24T20:17:02.888032",
+                    "mimetype": "application/geopackage+sqlite3",
+                    "mimetype_inner": null,
+                    "name": "watersheds_gura.gpkg",
+                    "package_id": "41c970f4-20ba-4263-8573-a66bba42202e",
+                    "position": 1,
+                    "resource_type": null,
+                    "size": null,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/dataset/watersheds_gura.gpkg",
+                    "url_type": null
+                }
+            ],
+            "tags": [
+                {
+                    "display_name": "DELINEATEIT",
+                    "id": "e5dd2106-b97f-4e16-8420-f5f41570c7b7",
+                    "name": "DELINEATEIT",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "INVEST",
+                    "id": "2d01b3c1-9fa8-4057-990b-9ca854104dd7",
+                    "name": "INVEST",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "WATERSHEDS",
+                    "id": "73fc5f83-66bf-4363-bc68-4514403f6396",
+                    "name": "WATERSHEDS",
+                    "state": "active",
+                    "vocabulary_id": null
+                }
+            ],
+            "groups": [],
+            "relationships_as_subject": [],
+            "relationships_as_object": [],
+            "tracking_summary": {
+                "total": 0,
+                "recent": 0
+            }
+        },
+        {
+            "author": "The Natural Capital Project, Stanford University",
+            "author_email": "datahub@naturalcapitalproject.org",
+            "collection": [],
+            "creator_user_id": "7a4d74f2-b39a-4c5b-ab4a-41bbcabfd470",
+            "id": "8693d274-e70a-402f-a5f0-9d0b3b4871e7",
+            "isopen": true,
+            "license_id": "CC-BY-4.0",
+            "license_title": "Creative Commons Attribution 4.0",
+            "license_url": "https://creativecommons.org/licenses/by/4.0/",
+            "metadata_created": "2026-04-24T20:29:55.335003",
+            "metadata_modified": "2026-04-24T20:29:56.005198",
+            "name": "sts-c874158d1857b2289f701861941d37a48b156c437b84867248b862a62681e692",
+            "notes": "Table of biophysical values for each watershed",
+            "num_resources": 2,
+            "num_tags": 3,
+            "organization": {
+                "id": "db21312f-31cd-4be0-b04a-451b45b6facc",
+                "name": "natcap",
+                "title": "natcap",
+                "type": "organization",
+                "description": "",
+                "image_url": "",
+                "created": "2025-05-15T15:27:25.720453",
+                "is_organization": true,
+                "approval_status": "approved",
+                "state": "active"
+            },
+            "owner_org": "db21312f-31cd-4be0-b04a-451b45b6facc",
+            "place": [],
+            "private": false,
+            "state": "active",
+            "suggested_citation": "",
+            "title": "SWY Watersheds for Testing",
+            "type": "dataset",
+            "version": "",
+            "extras": [
+                {
+                    "key": "center_lat_lon",
+                    "value": "[-0.5645034753354095, 36.88701122767153]"
+                },
+                {
+                    "key": "sources",
+                    "value": "[\"/aggregated_results_swy_gura.shp\", \"/aggregated_results_swy_gura.shx\", \"/aggregated_results_swy_gura.dbf\", \"/aggregated_results_swy_gura.prj\"]"
+                },
+                {
+                    "key": "sources_res_formats",
+                    "value": "[\"shp\", \"yml\"]"
+                },
+                {
+                    "key": "spatial",
+                    "value": "{\"type\": \"Polygon\", \"coordinates\": [[[36.744613360150325, -0.5255371965319794], [36.744613360150325, -0.6068670102422887], [37.00544990906099, -0.6068670102422887], [37.00544990906099, -0.5255371965319794], [36.744613360150325, -0.5255371965319794]]]}"
+                }
+            ],
+            "resources": [
+                {
+                    "cache_last_updated": "2026-04-24T16:29:55.282241",
+                    "cache_url": null,
+                    "created": "2026-04-24T16:29:55.282241",
+                    "datastore_active": false,
+                    "description": "Geometamaker YML",
+                    "format": "YML",
+                    "hash": "sha256:90dda8cbd7a0761939717473f0514484c4d45700bef92b6a3e6834e5b15b3288",
+                    "id": "ac72d382-226f-4129-b9cf-80e9b57127b2",
+                    "last_modified": "2026-04-24T20:29:55.897260",
+                    "metadata_modified": "2026-04-24T20:29:56.007208",
+                    "mimetype": null,
+                    "mimetype_inner": null,
+                    "name": "aggregated_results_swy_gura.shp.yml",
+                    "package_id": "8693d274-e70a-402f-a5f0-9d0b3b4871e7",
+                    "position": 0,
+                    "resource_type": null,
+                    "size": 3800,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/dataset/8693d274-e70a-402f-a5f0-9d0b3b4871e7/resource/ac72d382-226f-4129-b9cf-80e9b57127b2/download/aggregated_results_swy_gura.shp.yml",
+                    "url_type": "upload"
+                },
+                {
+                    "cache_last_updated": "2026-04-24T16:29:55.282474",
+                    "cache_url": null,
+                    "created": "2026-04-24T16:29:55.282473",
+                    "datastore_active": false,
+                    "description": "Table of biophysical values for each watershed",
+                    "format": ".shp",
+                    "hash": "",
+                    "id": "36656b0d-d45d-4c1e-bb6c-e26e2f9723b9",
+                    "last_modified": null,
+                    "metadata_modified": "2026-04-24T20:29:56.007322",
+                    "mimetype": "application/octet-stream",
+                    "mimetype_inner": null,
+                    "name": "aggregated_results_swy_gura.shp",
+                    "package_id": "8693d274-e70a-402f-a5f0-9d0b3b4871e7",
+                    "position": 1,
+                    "resource_type": null,
+                    "size": null,
+                    "state": "active",
+                    "tracking_summary": {
+                        "total": 0,
+                        "recent": 0
+                    },
+                    "url": "https://data.naturalcapitalalliance.stanford.edu/dataset/aggregated_results_swy_gura.shp",
+                    "url_type": null
+                }
+            ],
+            "tags": [
+                {
+                    "display_name": "INVEST",
+                    "id": "2d01b3c1-9fa8-4057-990b-9ca854104dd7",
+                    "name": "INVEST",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "SEASONAL WATER YIELD",
+                    "id": "99d7f2ca-6a8a-4b88-893a-9657e88255bf",
+                    "name": "SEASONAL WATER YIELD",
+                    "state": "active",
+                    "vocabulary_id": null
+                },
+                {
+                    "display_name": "WATERSHEDS",
+                    "id": "73fc5f83-66bf-4363-bc68-4514403f6396",
+                    "name": "WATERSHEDS",
+                    "state": "active",
+                    "vocabulary_id": null
+                }
+            ],
+            "groups": [],
+            "relationships_as_subject": [],
+            "relationships_as_object": [],
+            "tracking_summary": {
+                "total": 0,
+                "recent": 0
+            }
+        }
+    ],
+    "sort": "score desc",
+    "search_facets": {}
+}

--- a/tests/test_data/formatted_payload_multiple_resource_match.json
+++ b/tests/test_data/formatted_payload_multiple_resource_match.json
@@ -1,0 +1,35 @@
+{
+    "count": 1,
+    "datasets": [
+        {
+            "dataset_url": "https://storage.googleapis.com/natcap-data-cache/global/esa2021/esa2021.tif",
+            "source_catalog_url": "https://data.naturalcapitalalliance.stanford.edu/dataset/sts-476a98658e58fb224e1c6fdade4cc5ccbc208b441e3f081da455db17eb6f738f",
+            "name": "ESA WorldCover 2021",
+            "description": "This dataset provides a Global ESA 2021 (Version 2) Land Use Land Cover raster file at a resolution of 10m. Included  LULC classes are: Tree cover, Shrubland, Grassland, Cropland, Built-up, Bare/sparse vegetation, Snow and Ice, Permenent water bodies, Herbaceous wetland, Mangroves, and Moss and lichen. Please download the esa2021_classes.csv file alongside the raster for access to the classes legend. This data was accessed from https://worldcover2021.esa.int/download and each tile was downloaded and stitched together into a Global raster by analysts at the Natural Capital Project. The global layer was then converted into a Cloud Optimized GeoTiff with internal overviews. Citation information, and technical documentation, can be found at: https://worldcover2021.esa.int/documentation",
+            "extent": [
+                -180.0,
+                -59.999999999995005,
+                179.99999999998747,
+                84.00000000000001
+            ],
+            "tags": [
+                "ESA",
+                "EUROPEAN SPACE AGENCY",
+                "LAND USE LAND COVER",
+                "LULC"
+            ],
+            "places": [
+                "GLOBAL"
+            ],
+            "collection": [],
+            "license": {
+                "id": "CC-BY-4.0",
+                "title": "Creative Commons Attribution 4.0",
+                "url": "https://creativecommons.org/licenses/by/4.0/"
+            },
+            "author": "Natural Capital Project, Stanford University",
+            "created": "2025-06-27T19:47:57.098766",
+            "last_updated": "2025-08-28T19:05:48.398372"
+        }
+    ]
+}

--- a/tests/test_data/formatted_payload_no_resource_match.json
+++ b/tests/test_data/formatted_payload_no_resource_match.json
@@ -1,0 +1,38 @@
+{
+    "count": 1,
+    "datasets": [
+        {
+            "dataset_url": "https://data.naturalcapitalalliance.stanford.edu/download/global/noaa-us-shorelines/noaa_us_shorelines/noaa_us_shorelines.shp",
+            "source_catalog_url": "https://data.naturalcapitalalliance.stanford.edu/dataset/sts-bf98ba4d4020c364153efb4a324d4e39d2d9e3cc9978d2afdc729fac664069cf",
+            "name": "NOAA CUSP US Shorelines",
+            "description": "This dataset is a product of NOAA's NGS CUSP (Continually Updated Shoreline Product) that provides the most current shorelines of the US and US territories and references mean high water. The data provided by NASA was downloaded and stitched into a single shapefile by members of the NatCap team. This data is continuously updated by the NOAA team and was last downloaded and stitched on 2025-08-01 for the Data Hub. Data will continue to be updated periodically. For more information on the data, including details on the source of the dataset, please see the accompanying metadata (YML) file. For more information from NOAA directly, please visit https://nsde.ngs.noaa.gov/.",
+            "extent": [
+                -179.1501203785526,
+                -14.548575000435905,
+                174.17894858272027,
+                71.38773242211363
+            ],
+            "tags": [
+                "COASTAL",
+                "COASTLINE",
+                "NOAA",
+                "SHORELINES"
+            ],
+            "places": [
+                "PACIFIC ISLANDS",
+                "PUERTO RICO",
+                "UNITED STATES",
+                "US VIRGIN ISLANDS"
+            ],
+            "collection": [],
+            "license": {
+                "id": "other-pd",
+                "title": "Other (Public Domain)",
+                "url": null
+            },
+            "author": "Natural Capital Alliance, Stanford University",
+            "created": "2026-02-24T19:00:04.857844",
+            "last_updated": "2026-03-31T16:05:07.761792"
+        }
+    ]
+}

--- a/tests/test_data/formatted_payload_simple.json
+++ b/tests/test_data/formatted_payload_simple.json
@@ -1,0 +1,36 @@
+{
+    "count": 1,
+    "datasets": [
+        {
+            "dataset_url": "https://storage.googleapis.com/natcap-data-cache/global/nasa-hgt-v1-1s/nasa-hgt-v1-1s.tif",
+            "source_catalog_url": "https://data.naturalcapitalalliance.stanford.edu/dataset/sts-2b13519934614f4b36243eaeab5c712f37043413fb6fc314d588229a47808157",
+            "name": "NASA HGT DEM - Global Dataset",
+            "description": "NASA DEM HGT version 1 - Global Layer. 30m pixel size. NASADEM 1 arc second (30m) elevation data (collected over the Grand Canyon between 2000-02-11 to 2000-02-21). All tiles were downloaded from NASA Earth Data and stitched into one Cloud Optimized GeoTiff raster. More information on the dataset can be found in the metadata YML file available for download. More information on the source data can found here: https://lpdaac.usgs.gov/products/nasadem_hgtv001/.",
+            "extent": [
+                -179.0001388888889,
+                -56.000138888904445,
+                179.0001388889365,
+                61.00013888888889
+            ],
+            "tags": [
+                "DEM",
+                "DIGITAL ELEVATION MODEL",
+                "INVEST INPUT",
+                "INVEST-READY",
+                "NASA"
+            ],
+            "places": [
+                "GLOBAL"
+            ],
+            "collection": [],
+            "license": {
+                "id": "CC-BY-4.0",
+                "title": "Creative Commons Attribution 4.0",
+                "url": "https://creativecommons.org/licenses/by/4.0/"
+            },
+            "author": "Natural Capital Project, Stanford University",
+            "created": "2025-06-13T19:53:53.233509",
+            "last_updated": "2025-08-28T19:06:00.531711"
+        }
+    ]
+}

--- a/tests/test_data/formatted_payload_vector_formats.json
+++ b/tests/test_data/formatted_payload_vector_formats.json
@@ -1,0 +1,59 @@
+{
+    "count": 2,
+    "datasets": [
+        {
+            "dataset_url": "https://data.naturalcapitalalliance.stanford.edu/dataset/watersheds_gura.gpkg",
+            "source_catalog_url": "https://data.naturalcapitalalliance.stanford.edu/dataset/sts-dafff9535f9b2b329ec61e85a481a16776304708af291ddc5792f8d695278264",
+            "name": "Subwatersheds from DelineateIt for Testing",
+            "description": "A vector defining the areas that are upstream from the snapped outlet points, where upstream area is defined by the D8 flow algorithm implementation in PyGeoprocessing.",
+            "extent": [
+                36.744343840599385,
+                -0.60712559476077,
+                36.97163097658486,
+                -0.5359785856603112
+            ],
+            "tags": [
+                "DELINEATEIT",
+                "INVEST",
+                "WATERSHEDS"
+            ],
+            "places": [],
+            "collection": [],
+            "license": {
+                "id": "CC-BY-4.0",
+                "title": "Creative Commons Attribution 4.0",
+                "url": "https://creativecommons.org/licenses/by/4.0/"
+            },
+            "author": "The Natural Capital Project, Stanford University",
+            "created": "2026-04-24T20:12:43.322088",
+            "last_updated": "2026-04-24T20:17:02.885906"
+        },
+        {
+            "dataset_url": "https://data.naturalcapitalalliance.stanford.edu/dataset/aggregated_results_swy_gura.shp",
+            "source_catalog_url": "https://data.naturalcapitalalliance.stanford.edu/dataset/sts-c874158d1857b2289f701861941d37a48b156c437b84867248b862a62681e692",
+            "name": "SWY Watersheds for Testing",
+            "description": "Table of biophysical values for each watershed",
+            "extent": [
+                36.744613360150325,
+                -0.6068670102422887,
+                37.00544990906099,
+                -0.5255371965319794
+            ],
+            "tags": [
+                "INVEST",
+                "SEASONAL WATER YIELD",
+                "WATERSHEDS"
+            ],
+            "places": [],
+            "collection": [],
+            "license": {
+                "id": "CC-BY-4.0",
+                "title": "Creative Commons Attribution 4.0",
+                "url": "https://creativecommons.org/licenses/by/4.0/"
+            },
+            "author": "The Natural Capital Project, Stanford University",
+            "created": "2026-04-24T20:29:55.335003",
+            "last_updated": "2026-04-24T20:29:56.005198"
+        }
+    ]
+}


### PR DESCRIPTION
Initial groundwork for interfacing between InVEST and the Data Hub. 

I've written some basic testing using mocked-out CKAN responses, to ensure the DHAL is parsing the CKAN return payload in the expected manner. Eventually I'd love to be able to run tests against a CKAN instance that mimics production (but with a predictable database state w/r/t the Packages and Resources).

For the purposes of early dev, `main.py` includes the URLs and vocabulary IDs for the Production and Staging Data Hub instances, as well as for my local CKAN instance. Once we get closer to putting this API into production, we should remove the non-production Hub details. We also recently moved the staging Hub behind a login to prevent bot traffic. Since I imagine we may want to develop against staging (we have more freedom to experiment with datasets there), I've also included handling for setting the necessary authorization header when working with staging. You'll need to set `CKAN_STAGING_USERNAME` and `CKAN_STAGING_PASSWORD` in your environment before running `fastapi dev` (I can provide credentials if needed). This is also documented in the README. 